### PR TITLE
Suppress repeated soft-bounce content rejections (#37)

### DIFF
--- a/app/api/webhooks/resend/route.ts
+++ b/app/api/webhooks/resend/route.ts
@@ -28,11 +28,22 @@ import { NextResponse } from "next/server";
 import { Webhook } from "svix";
 import { unsubscribeByEmail } from "@/lib/subscribers";
 import {
+  countRecentBouncesOfSubType,
   hasWebhookEvent,
   recordEmailEvent,
   recordWebhookEvent,
   truncateIp,
 } from "@/lib/webhooks";
+
+// Soft-bounce subtypes Resend classifies as `Transient` but which, in practice,
+// recur with the same content rejection (Apple's CS01 reputation reject is the
+// canonical case). Counted across a rolling window; once a recipient hits the
+// threshold we treat it like a hard bounce and unsubscribe. The threshold
+// counts PRIOR bounces — so a value of 1 means "suppress on the 2nd occurrence
+// in the window", giving every recipient one fluke chance before we stop.
+const SOFT_BOUNCE_SUPPRESS_SUBTYPES = ["ContentRejected"] as const;
+const SOFT_BOUNCE_WINDOW_DAYS = 30;
+const SOFT_BOUNCE_PRIOR_THRESHOLD = 1;
 
 export const runtime = "nodejs";
 
@@ -131,22 +142,50 @@ export async function POST(req: Request) {
         break;
       }
       case "email.bounced": {
-        // Resend marks hard vs soft bounces via data.bounce.type. Only hard
-        // bounces auto-unsubscribe; soft bounces are retried by Resend itself.
-        // The event is recorded regardless so the search shows "Bounced".
+        // Resend marks hard vs soft bounces via data.bounce.type. Hard bounces
+        // auto-unsubscribe immediately. Soft bounces normally just get recorded
+        // (Resend retries on its own) — EXCEPT when the subType is one we know
+        // recurs with the same content rejection. Apple's CS01 reputation
+        // bounce arrives as Transient/ContentRejected but the same recipient
+        // bounces every day; continuing to send only worsens our reputation,
+        // so we suppress after the threshold prior occurrences in the window.
         const bounceType = event.data?.bounce?.type?.toLowerCase();
+        const bounceSubType = event.data?.bounce?.subType ?? null;
         const isHard = bounceType === "hard" || bounceType === "permanent";
-        if (isHard) {
-          const email = recipientOf(event);
-          if (email) {
-            const sub = await unsubscribeByEmail(email, "bounce");
-            actionResult = { action: sub ? "unsubscribed" : "noop", email, bounceType };
-          } else {
-            console.warn(`bounce event ${svixId} has no recipient`);
-            actionResult = { action: "no_recipient", bounceType };
+        const email = recipientOf(event);
+
+        let suppressReason: "hard" | "repeated_soft" | null = isHard ? "hard" : null;
+
+        if (
+          !isHard
+          && email
+          && bounceSubType
+          && (SOFT_BOUNCE_SUPPRESS_SUBTYPES as readonly string[]).includes(bounceSubType)
+        ) {
+          const priorCount = await countRecentBouncesOfSubType(
+            email,
+            bounceSubType,
+            SOFT_BOUNCE_WINDOW_DAYS,
+          );
+          if (priorCount >= SOFT_BOUNCE_PRIOR_THRESHOLD) {
+            suppressReason = "repeated_soft";
           }
+        }
+
+        if (suppressReason && email) {
+          const sub = await unsubscribeByEmail(email, "bounce");
+          actionResult = {
+            action: sub ? "unsubscribed" : "noop",
+            email,
+            bounceType,
+            bounceSubType,
+            suppressReason,
+          };
+        } else if (suppressReason && !email) {
+          console.warn(`bounce event ${svixId} has no recipient`);
+          actionResult = { action: "no_recipient", bounceType, bounceSubType };
         } else {
-          actionResult = { action: "soft_bounce_recorded", bounceType };
+          actionResult = { action: "soft_bounce_recorded", bounceType, bounceSubType };
         }
         await logEmailEvent(event);
         break;

--- a/lib/webhooks.ts
+++ b/lib/webhooks.ts
@@ -65,6 +65,35 @@ export async function recordEmailEvent(args: {
   if (error) throw new Error(`recordEmailEvent: ${error.message}`);
 }
 
+// Count prior bounce events of a specific subType for a recipient, within a
+// time window. Used to detect repeated soft bounces that should be treated as
+// effectively permanent — Apple's `554 5.7.1 [CS01]` reputation rejection
+// arrives as `bounce.type="Transient"` `subType="ContentRejected"`, so Resend
+// classifies it as soft. In practice the same recipient bounces every day with
+// the same code, and continuing to send to them only further damages our
+// domain reputation with Apple.
+//
+// Counts on email_events.payload (set to `event.data` at record time), which
+// already contains both the `to` array and the bounce envelope. We don't keep
+// a recipient column on email_events — payload containment is sufficient.
+export async function countRecentBouncesOfSubType(
+  email: string,
+  subType: string,
+  withinDays: number,
+): Promise<number> {
+  const since = new Date(Date.now() - withinDays * 24 * 3600 * 1000).toISOString();
+  const normalized = email.trim().toLowerCase();
+  const { count, error } = await supabaseAdmin()
+    .from("email_events")
+    .select("id", { count: "exact", head: true })
+    .eq("event_type", "email.bounced")
+    .gte("event_at", since)
+    .contains("payload", { to: [normalized] })
+    .eq("payload->bounce->>subType", subType);
+  if (error) throw new Error(`countRecentBouncesOfSubType: ${error.message}`);
+  return count ?? 0;
+}
+
 // Truncate an IP address for privacy. IPv4 → keep first three octets and zero
 // the fourth (/24). IPv6 → keep first three 16-bit groups (/48). Best-effort:
 // returns null if the input isn't a parseable address.

--- a/scripts/backfill-content-rejected-suppressions.ts
+++ b/scripts/backfill-content-rejected-suppressions.ts
@@ -1,0 +1,81 @@
+// One-time backfill for issue #37.
+//
+// Before the soft-bounce-suppression fix landed, recipients hitting Apple's
+// CS01 (Transient / ContentRejected) reputation reject would bounce every day
+// without ever being unsubscribed. This script finds every recipient with N+
+// ContentRejected bounces in the last WINDOW_DAYS and unsubscribes them with
+// reason='bounce'. After this runs once, the webhook handler keeps the list
+// clean going forward.
+//
+// Usage: npx tsx scripts/backfill-content-rejected-suppressions.ts
+//        (add --dry to preview without writing)
+
+import { supabaseAdmin } from "../lib/supabase";
+import { unsubscribeByEmail } from "../lib/subscribers";
+
+const SUBTYPE = "ContentRejected";
+const WINDOW_DAYS = 30;
+const MIN_BOUNCES = 2;
+const DRY_RUN = process.argv.includes("--dry");
+
+async function main() {
+  const since = new Date(Date.now() - WINDOW_DAYS * 24 * 3600 * 1000).toISOString();
+  const db = supabaseAdmin();
+
+  // Pull every ContentRejected bounce in the window. Volume is small (a few
+  // hundred rows over 30 days), so a paginated scan + JS aggregation is fine.
+  const counts = new Map<string, number>();
+  let from = 0;
+  const pageSize = 1000;
+  while (true) {
+    const { data, error } = await db
+      .from("email_events")
+      .select("payload")
+      .eq("event_type", "email.bounced")
+      .gte("event_at", since)
+      .eq("payload->bounce->>subType", SUBTYPE)
+      .range(from, from + pageSize - 1);
+    if (error) throw new Error(`scan: ${error.message}`);
+    if (!data || data.length === 0) break;
+    for (const row of data) {
+      const payload = row.payload as { to?: string[] | string } | null;
+      if (!payload) continue;
+      const to = Array.isArray(payload.to) ? payload.to[0] : payload.to;
+      if (!to) continue;
+      const email = to.trim().toLowerCase();
+      counts.set(email, (counts.get(email) ?? 0) + 1);
+    }
+    if (data.length < pageSize) break;
+    from += pageSize;
+  }
+
+  const candidates = [...counts.entries()]
+    .filter(([, n]) => n >= MIN_BOUNCES)
+    .sort((a, b) => b[1] - a[1]);
+
+  console.log(`Scanned ${WINDOW_DAYS}d, ${counts.size} distinct recipients with ${SUBTYPE} bounces.`);
+  console.log(`${candidates.length} recipients hit ${MIN_BOUNCES}+ bounces.\n`);
+
+  let unsubscribed = 0;
+  let skipped = 0;
+  for (const [email, n] of candidates) {
+    if (DRY_RUN) {
+      console.log(`[dry] would unsubscribe ${email} (${n} bounces)`);
+      continue;
+    }
+    const sub = await unsubscribeByEmail(email, "bounce");
+    if (sub) {
+      unsubscribed++;
+      console.log(`unsubscribed ${email} (${n} bounces)`);
+    } else {
+      skipped++;
+    }
+  }
+
+  console.log(`\nDone. unsubscribed=${unsubscribed} already_off=${skipped}${DRY_RUN ? " (dry run)" : ""}`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
Closes #37.

## What

Webhook handler now treats Resend `Transient` bounces with `subType: ContentRejected` as permanent once the recipient has had N+ such bounces in the trailing window. Same suppression path as hard bounces; same `unsubscribe_reason: "bounce"`.

Configurable at the top of `app/api/webhooks/resend/route.ts`:
- `SOFT_BOUNCE_SUPPRESS_SUBTYPES = ["ContentRejected"]` — add other recurring subtypes here as we learn them
- `SOFT_BOUNCE_WINDOW_DAYS = 30`
- `SOFT_BOUNCE_PRIOR_THRESHOLD = 1` — counts *prior* bounces, so suppression triggers on the 2nd occurrence (one fluke chance)

Counter is JSONB containment on `email_events.payload` (already stores `to` and `bounce.subType`) — no schema changes.

## Backfill

`scripts/backfill-content-rejected-suppressions.ts` — dry run shows **104 recipients** with 2+ ContentRejected bounces in last 30 days, with the worst at 10 bounces (10 daily retries of an address Apple has rejected every single time). Run once after merge:

```sh
npx tsx scripts/backfill-content-rejected-suppressions.ts        # live
npx tsx scripts/backfill-content-rejected-suppressions.ts --dry  # preview
```

## Why this should move the needle

Current Apple bounce rate ~85% of all bounces, ~90/day. After suppression:
- 104 recurrent bouncers leave the daily send
- Bounce-to-send ratio drops from ~5% to <0.5%
- Apple's CS01 trigger is a sender-reputation score; reduced bad-signal volume rebuilds the score over ~2–4 weeks
- New Apple recipients still hitting CS01 stop after their 2nd attempt instead of compounding the problem

## Test plan
- [ ] Run dry backfill — verify count and sample addresses look right
- [ ] Merge and run live backfill — verify ~100 subscribers flip to `status='unsubscribed'`, `unsubscribe_reason='bounce'`
- [ ] Tomorrow's digest run: Apple bounce count should drop to near-zero for already-known bouncers; only fresh CS01 events should appear
- [ ] Two days later: those fresh CS01 events should themselves get suppressed (2nd-occurrence rule)

## Out of scope (separate issues if pursued)

- Other soft-bounce subtypes (`MailboxFull`, `MessageTooLarge`) — file when we see recurrence
- Display-name-format `to` parsing (e.g. `"Thomas Cotton <thomas.cotton@gmail.com>"`) — affects gmail bounces, separate bug
- Adding Resend to SPF — DKIM aligns so DMARC is fine; cosmetic

🤖 Generated with [Claude Code](https://claude.com/claude-code)