### PR TITLE
Full-day digest as lead social image (#39)

### DIFF
--- a/app/api/cron/post-bluesky/route.ts
+++ b/app/api/cron/post-bluesky/route.ts
@@ -19,16 +19,6 @@ function isAuthorized(req: Request): boolean {
   return req.headers.get("authorization") === `Bearer ${secret}`;
 }
 
-// Read width/height from PNG header (IHDR chunk). Used so BlueSky renders
-// each image at its native aspect ratio instead of letterboxing.
-function readPngDimensions(bytes: Uint8Array): { width: number; height: number } | null {
-  if (bytes.length < 24) return null;
-  if (bytes[0] !== 0x89 || bytes[1] !== 0x50 || bytes[2] !== 0x4e || bytes[3] !== 0x47) return null;
-  const w = (bytes[16]! << 24) | (bytes[17]! << 16) | (bytes[18]! << 8) | bytes[19]!;
-  const h = (bytes[20]! << 24) | (bytes[21]! << 16) | (bytes[22]! << 8) | bytes[23]!;
-  return { width: w >>> 0, height: h >>> 0 };
-}
-
 export async function GET(req: Request) {
   if (!isAuthorized(req)) {
     return NextResponse.json({ error: "unauthorized" }, { status: 401 });
@@ -97,7 +87,7 @@ export async function GET(req: Request) {
   let posted = 0, skipped = 0, failed = 0;
   const results: Array<{ subId: string; url?: string; error?: string }> = [];
 
-  for (const { entry, png } of images) {
+  for (const { entry, png, mime, width, height } of images) {
     if (await hasAlreadyPosted("bluesky", sport, date, entry.subId)) {
       skipped++;
       results.push({ subId: entry.subId, url: "(already posted)" });
@@ -105,11 +95,11 @@ export async function GET(req: Request) {
     }
 
     const { text, alt } = imagePostContent(entry, pretty, digestUrl);
-    const dims = readPngDimensions(png) ?? undefined;
+    const dims = width > 0 && height > 0 ? { width, height } : undefined;
 
     try {
       const { uri, url: postUrl } = await postToBlueskyWithImage({
-        text, altText: alt, imageBytes: png, aspectRatio: dims,
+        text, altText: alt, imageBytes: png, imageMime: mime, aspectRatio: dims,
       });
       await recordPost({
         platform: "bluesky", sport, date, subId: entry.subId,

--- a/app/api/cron/post-twitter/route.ts
+++ b/app/api/cron/post-twitter/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { EUploadMimeType } from "twitter-api-v2";
 import { isValidIsoDate, prettyDate, yesterdayInET } from "@/lib/dates";
 import { hasAlreadyPosted, recordPost } from "@/lib/social-posts";
 import { deleteTweet, postTweetWithImage } from "@/lib/twitter";
@@ -79,7 +80,7 @@ export async function GET(req: Request) {
     let posted = 0, skipped = 0, failed = 0;
     const results: Array<{ subId: string; url?: string; error?: string }> = [];
 
-    for (const { entry, png } of images) {
+    for (const { entry, png, mime } of images) {
       if (await hasAlreadyPosted("twitter", sport, date, entry.subId)) {
         skipped++;
         results.push({ subId: entry.subId, url: "(already posted)" });
@@ -89,10 +90,11 @@ export async function GET(req: Request) {
       // No digestUrl for Twitter: URL-bearing posts cost $0.20 vs $0.015
       // without. The bio link covers click-through.
       const { text, alt } = imagePostContent(entry, pretty);
+      const mimeType = mime === "image/jpeg" ? EUploadMimeType.Jpeg : EUploadMimeType.Png;
 
       try {
         const { id, url: postUrl } = await postTweetWithImage({
-          text, altText: alt, imageBytes: png,
+          text, altText: alt, imageBytes: png, mimeType,
         });
         await recordPost({
           platform: "twitter", sport, date, subId: entry.subId,

--- a/lib/render-images.ts
+++ b/lib/render-images.ts
@@ -15,11 +15,19 @@ import { nextDay, prettyDate } from "./dates";
 export type ManifestEntry =
   | { file: string; subId: string; type: "standings"; league: "AL" | "NL" }
   | { file: string; subId: string; type: "leaders"; league: "AL" | "NL" }
-  | { file: string; subId: string; type: "boxscore"; title: string; teams: [string, string] };
+  | { file: string; subId: string; type: "boxscore"; title: string; teams: [string, string] }
+  | { file: string; subId: string; type: "full"; gameCount: number };
+
+export type ImageMime = "image/png" | "image/jpeg";
 
 export type RenderedImage = {
   entry: ManifestEntry;
+  // Image bytes. Format is given by `mime` — historically PNG for per-section
+  // images; the full-day capture is JPEG to fit Bluesky's 1MB cap.
   png: Uint8Array;
+  mime: ImageMime;
+  width: number;   // physical pixels
+  height: number;  // physical pixels
 };
 
 // Must match the installed version of @sparticuz/chromium-min. The `pack.x64`
@@ -224,11 +232,80 @@ export async function renderShareImages(args: {
     for (const { handle, entry } of captures) {
       await handle.scrollIntoView();
       const png = (await handle.screenshot({ type: "png" })) as Uint8Array;
-      results.push({ entry, png });
+      const box = await handle.boundingBox();
+      // boundingBox is CSS px; physical pixels = CSS × deviceScaleFactor (=2 here).
+      const width = box ? Math.round(box.width * 2) : 0;
+      const height = box ? Math.round(box.height * 2) : 0;
+      results.push({ entry, png, mime: "image/png", width, height });
+    }
+
+    // Full-day capture. Posted as the LEAD image — the goal is the tall,
+    // crop-with-tap-to-expand preview on Twitter/Bluesky that hooks scrollers
+    // by showing "all of today's box scores in one shot."
+    //
+    // Constraints driving the format choice:
+    //   - Bluesky caps images at 1MB. A 2x DPR PNG of a 15-game day blows
+    //     past that easily; JPEG at quality ~85 stays well under for
+    //     text-on-white content.
+    //   - Twitter caps any dimension at 8192px. Dropping to 1x DPR and a
+    //     ~600px logical width keeps us inside that limit for the typical
+    //     15-game day; rare 20+ game Saturdays may still exceed and would
+    //     need a follow-up scale-down (see issue #39 "out of scope").
+    //
+    // The capture targets the whole document at 1x DPR after hiding the
+    // site-header/footer chrome so only the digest content lands in the
+    // image. Reusing the same page also means the share-CSS column layout
+    // already injected stays in effect.
+    const fullImage = await captureFullDigest(page, games.length);
+    if (fullImage) {
+      // Prepend so it's the first thing posted, before any per-section follow-ups.
+      results.unshift(fullImage);
     }
 
     return results;
   } finally {
     await browser.close();
   }
+}
+
+const FULL_CAPTURE_WIDTH = 600;       // CSS px; matches the 540px share blocks + a little breathing room
+const FULL_JPEG_QUALITY = 85;
+
+async function captureFullDigest(page: Page, gameCount: number): Promise<RenderedImage | null> {
+  // Hide the site header/footer that wrap the digest body — they're not part
+  // of the data and would only add chrome noise to the share image.
+  await page.addStyleTag({
+    content: `
+      .site-header, .site-footer { display: none !important; }
+      body, .newspaper { background: #fff !important; }
+    `,
+  });
+  // Drop to 1x DPR and snap viewport width so the captured page is tight
+  // around the centered 540px column. Triggers a relayout; small wait lets
+  // the column-flex reflow settle before screenshotting.
+  await page.setViewport({
+    width: FULL_CAPTURE_WIDTH,
+    height: 1024,
+    deviceScaleFactor: 1,
+  });
+  await page.waitForFunction(() => document.fonts?.ready ?? Promise.resolve());
+  await new Promise((r) => setTimeout(r, 300));
+
+  const dims = await page.evaluate(() => ({
+    width: document.documentElement.scrollWidth,
+    height: document.documentElement.scrollHeight,
+  }));
+  const png = (await page.screenshot({
+    fullPage: true,
+    type: "jpeg",
+    quality: FULL_JPEG_QUALITY,
+  })) as Uint8Array;
+
+  return {
+    entry: { file: "full.jpg", subId: "full", type: "full", gameCount },
+    png,
+    mime: "image/jpeg",
+    width: dims.width,
+    height: dims.height,
+  };
 }

--- a/lib/share-storage.ts
+++ b/lib/share-storage.ts
@@ -51,10 +51,10 @@ export async function uploadShareImages(args: {
   await clearShareImages();
   const supa = supabaseAdmin();
   const entries: ManifestImage[] = [];
-  for (const { entry, png } of args.images) {
+  for (const { entry, png, mime } of args.images) {
     const path = `${args.date}_${entry.file}`;
     const { error } = await supa.storage.from(BUCKET).upload(path, png, {
-      contentType: "image/png",
+      contentType: mime,
       upsert: true,
     });
     if (error) throw new Error(`storage upload ${path}: ${error.message}`);
@@ -110,6 +110,7 @@ export async function listStoredImages(): Promise<{ date: string | null; images:
 }
 
 function imagePriority(file: string): number {
+  if (file === "full.jpg" || file === "full.png") return 0;
   if (file === "al-standings.png") return 1;
   if (file === "al-leaders.png") return 2;
   if (file === "nl-standings.png") return 3;

--- a/lib/social-content.ts
+++ b/lib/social-content.ts
@@ -94,6 +94,14 @@ export function imagePostContent(
   // Twitter charges $0.20/post when a URL is present (vs $0.015 without), so
   // the Twitter paths pass digestUrl=undefined. Bluesky still includes it.
   const tail = digestUrl ? ` ${digestUrl}` : "";
+  if (entry.type === "full") {
+    const games = entry.gameCount;
+    const gamesLabel = games === 1 ? "1 game" : `${games} games`;
+    return {
+      text: `⚾ MLB box scores · ${prettyDate} · ${gamesLabel}\n\n#MLB${tail}`,
+      alt: `Full MLB digest for ${prettyDate}: standings, leaders, and box scores for all ${gamesLabel}.`,
+    };
+  }
   if (entry.type === "standings") {
     const name = entry.league === "AL" ? "American League" : "National League";
     return {


### PR DESCRIPTION
Closes #39.

## What

Adds a new \`\"full\"\` ManifestEntry that captures the entire boxscores page as one tall JPEG. Prepended to the image list so it's the first thing posted on Twitter and Bluesky — the per-section images still post afterwards as the series of follow-ups.

## How the capture works

After the existing per-section captures finish at 2x DPR:

1. Inject CSS to hide \`.site-header\` / \`.site-footer\` so only digest content lands in the image
2. \`page.setViewport({ width: 600, height: 1024, deviceScaleFactor: 1 })\` — tight around the 540px share column, 1x DPR to stay inside Twitter's 8192px dimension cap
3. Wait for fonts + relayout
4. \`page.screenshot({ fullPage: true, type: \"jpeg\", quality: 85 })\` — JPEG so it fits Bluesky's 1MB cap

## Plumbing changes

- \`RenderedImage\` now carries \`mime\`, \`width\`, \`height\` — populated at capture time
- \`post-bluesky\` route deletes the bespoke PNG header parser; uses the carried dims
- \`post-twitter\` route passes \`mimeType: EUploadMimeType.Jpeg\` when the entry is JPEG
- \`share-storage\` uploads with per-image \`contentType\` instead of hardcoded \`image/png\`
- \`social-content\` adds the \`\"full\"\` case: \`⚾ MLB box scores · {date} · {n} games · #MLB [url]\`
- Image sort priority puts \`full.jpg\` at the top of the admin gallery

## Test plan

- [ ] \`npm run typecheck\` clean (verified locally)
- [ ] Trigger \`/admin/images\` regenerate for yesterday — verify \`full.jpg\` shows up and visually contains standings + leaders + every boxscore in one stack
- [ ] Inspect the JPEG file size in Supabase Storage — should be well under 1MB for a 15-game day
- [ ] Manually post to Bluesky/Twitter from admin to confirm aspect ratio and feed-preview cropping look right before the next scheduled cron run

## Known limits (called out in #39)

- 16+ game days may push past Twitter's 8192px height limit. Falls back to whatever Twitter does with oversize uploads (usually rejects); we'll see it in cron-runs failures and can address with a follow-up scale-down step.
- Facebook album cron now includes \`full.jpg\` as one of the album photos. Probably fine, possibly redundant — easy to filter out later if undesirable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)