### PR TITLE
Add /redbaron77 — two 2025 Astros box scores in social-image format

### DIFF
--- a/app/redbaron77/page.tsx
+++ b/app/redbaron77/page.tsx
@@ -1,0 +1,71 @@
+import { notFound } from "next/navigation";
+import { loadHistoricalBoxHtml } from "@/lib/historical/render-game";
+import { prettyDate } from "@/lib/dates";
+import { BRAND } from "@/lib/brand";
+
+// Standalone vanity page: two specific 2025 Astros box scores rendered in the
+// standard boxscore social-image chrome (cream card, wordmark + date header,
+// tagline + URL footer — matches lib/scoreboard-image.tsx and the share
+// images from lib/render-images.ts). Not linked from anywhere.
+
+export const dynamic = "force-dynamic";
+export const metadata = {
+  title: "boxscore",
+  robots: { index: false, follow: false },
+};
+
+const GAMES = [
+  { gamePk: 776531 }, // 2025-08-30 LAA @ HOU
+  { gamePk: 777494 }, // 2025-06-15 MIN @ HOU
+];
+
+const PAPER = "#f9f7f1";
+const INK = "#161410";
+const RULE = "#c4baa5";
+const MUTED = "#6a6354";
+
+export default async function RedBaron77() {
+  const cards = await Promise.all(GAMES.map((g) => loadHistoricalBoxHtml(g.gamePk)));
+  const loaded = cards.filter((c): c is NonNullable<typeof c> => c !== null);
+  if (loaded.length === 0) notFound();
+
+  return (
+    <div style={{ background: "#e9e5da", padding: "28px 16px", minHeight: "100vh" }}>
+      <div style={{ maxWidth: 520, margin: "0 auto", display: "flex", flexDirection: "column", gap: 28 }}>
+        {loaded.map((c) => (
+          <div
+            key={c.gameDate + c.awayName}
+            style={{
+              background: PAPER,
+              border: `1px solid ${INK}`,
+              padding: "26px 30px 22px",
+              boxShadow: "0 2px 10px rgba(0,0,0,0.12)",
+              fontFamily: "'Source Sans 3', Helvetica, Arial, sans-serif",
+              color: INK,
+            }}
+          >
+            {/* Share-image header — logo + wordmark left, game date right. */}
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", borderBottom: `2px solid ${INK}`, paddingBottom: 12, marginBottom: 16 }}>
+              <div style={{ display: "flex", alignItems: "center", gap: 10, fontSize: 26, fontWeight: 800, letterSpacing: "-0.01em" }}>
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img src="/icon.png" alt="" width={38} height={38} style={{ borderRadius: 6, display: "block" }} />
+                boxscore
+              </div>
+              <div style={{ fontSize: 15, fontStyle: "italic", color: MUTED }}>{prettyDate(c.gameDate)}</div>
+            </div>
+
+            {/* The box score itself — renderGame() output, styled by globals.css.
+                Box-score classes aren't .newspaper-scoped, so no wrapper needed. */}
+            <div dangerouslySetInnerHTML={{ __html: c.html }} />
+
+            {/* Share-image footer — tagline left, marketing URL right. */}
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", borderTop: `2px solid ${RULE}`, marginTop: 16, paddingTop: 12, fontSize: 13, color: INK }}>
+              <div style={{ fontStyle: "italic", color: MUTED }}>{BRAND.tagline}</div>
+              <div style={{ letterSpacing: "0.18em", textTransform: "uppercase", fontWeight: 700 }}>boxscore.email/mlb</div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/lib/historical/render-game.ts
+++ b/lib/historical/render-game.ts
@@ -1,0 +1,111 @@
+// Render a single pre-2026 game's full box score from the historical store.
+//
+// Same recipe as the Time Machine game (app/games/time-machine/actions.ts):
+// historical raw payloads → GameDetail → renderGame(). Pulled into a plain
+// lib helper (not that "use server" actions file) so server components can
+// import it. Unlike Time Machine, this keeps the real venue/date — nothing
+// here is a puzzle to be kept year-safe.
+
+import { getHistoricalGameWithRaw, type HistoricalGameSummary } from "./queries";
+import {
+  parseBoxscore,
+  fetchPlayByPlayRaw,
+  parseScoringPlays,
+  type Boxscore,
+  type ScheduleGame,
+} from "@/lib/mlb";
+import { renderGame, type GameDetail } from "@/lib/render";
+
+type LinescoreEnvelope = {
+  innings?: Array<{ num: number; home?: { runs?: number }; away?: { runs?: number } }>;
+  currentInning?: number;
+  scheduledInnings?: number;
+  teams?: {
+    home?: { runs?: number; hits?: number; errors?: number };
+    away?: { runs?: number; hits?: number; errors?: number };
+  };
+};
+
+/** Build the renderGame-shaped ScheduleGame from a historical row + parsed box. */
+function synthesize(summary: HistoricalGameSummary, box: Boxscore, linescoreRaw: unknown): ScheduleGame {
+  const ls = (linescoreRaw ?? {}) as LinescoreEnvelope;
+  return {
+    gamePk: summary.game_pk,
+    gameDate: `${summary.game_date}T00:00:00Z`,
+    gameType: summary.game_type ?? undefined,
+    status: { abstractGameState: "Final", detailedState: "Final", codedGameState: "F" },
+    teams: {
+      away: {
+        team: {
+          id: box.teams.away.team.id,
+          name: box.teams.away.team.name,
+          abbreviation: box.teams.away.team.abbreviation,
+        },
+        score: summary.away_score ?? 0,
+      },
+      home: {
+        team: {
+          id: box.teams.home.team.id,
+          name: box.teams.home.team.name,
+          abbreviation: box.teams.home.team.abbreviation,
+        },
+        score: summary.home_score ?? 0,
+      },
+    },
+    linescore: {
+      currentInning: ls.currentInning,
+      scheduledInnings: ls.scheduledInnings,
+      innings: (ls.innings ?? []).map((i) => ({
+        num: i.num,
+        home: { runs: i.home?.runs },
+        away: { runs: i.away?.runs },
+      })),
+      teams: {
+        home: {
+          runs: ls.teams?.home?.runs ?? summary.home_score ?? 0,
+          hits: ls.teams?.home?.hits,
+          errors: ls.teams?.home?.errors,
+        },
+        away: {
+          runs: ls.teams?.away?.runs ?? summary.away_score ?? 0,
+          hits: ls.teams?.away?.hits,
+          errors: ls.teams?.away?.errors,
+        },
+      },
+    },
+  };
+}
+
+export type HistoricalBox = {
+  html: string;           // renderGame() output (.game-container)
+  awayName: string;
+  homeName: string;
+  gameDate: string;       // YYYY-MM-DD
+};
+
+/** Load one historical game and render its full box score HTML. */
+export async function loadHistoricalBoxHtml(gamePk: number): Promise<HistoricalBox | null> {
+  const summary = await getHistoricalGameWithRaw(gamePk);
+  if (!summary || !summary.boxscore_raw) return null;
+
+  const box = parseBoxscore(summary.boxscore_raw);
+  let scoring: Awaited<ReturnType<typeof parseScoringPlays>> = [];
+  try {
+    scoring = parseScoringPlays(await fetchPlayByPlayRaw(gamePk));
+  } catch {
+    /* PBP unavailable → renderer just omits the scoring block */
+  }
+
+  const game = synthesize(summary, box, summary.linescore_raw);
+  const detail: Required<GameDetail> = { game, box, scoring };
+  const liveAbbrev: Record<string, string> = {};
+  if (game.teams.away.team.abbreviation) liveAbbrev[game.teams.away.team.name] = game.teams.away.team.abbreviation;
+  if (game.teams.home.team.abbreviation) liveAbbrev[game.teams.home.team.name] = game.teams.home.team.abbreviation;
+
+  return {
+    html: renderGame(detail, liveAbbrev),
+    awayName: game.teams.away.team.name,
+    homeName: game.teams.home.team.name,
+    gameDate: summary.game_date,
+  };
+}


### PR DESCRIPTION
Standalone vanity page at `/redbaron77` rendering two specific historical games as full box scores inside the standard boxscore share-image chrome (cream card, wordmark + date header, tagline + URL footer).

- **2025-08-30** LAA @ HOU (Angels 4, Astros 1)
- **2025-06-15** MIN @ HOU (Astros 2, Twins 1)

`lib/historical/render-game.ts`: `loadHistoricalBoxHtml(gamePk)` — historical raw payloads → GameDetail → `renderGame()`, the same recipe Time Machine uses, in a plain lib so server components can import it. Page is `noindex`, not linked from anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)