### PR TITLE
Extend /mlb/art date floor to 1901

### DIFF
--- a/app/[sport]/art/page.tsx
+++ b/app/[sport]/art/page.tsx
@@ -54,7 +54,10 @@ export default async function BoxArtPage({
           id="date"
           name="date"
           defaultValue={validDate ?? ""}
-          min="1950-01-01"
+          /* statsapi's modern-era box scores start in 1901 (incl. the Negro
+             Leagues); older dates return no games. Not limited to our 1950+
+             DB — anything outside it renders via the statsapi fallback. */
+          min="1901-01-01"
           max={todayInET()}
           style={{ fontSize: 15, padding: "6px 8px", border: "1px solid var(--border-strong)", borderRadius: 0, fontFamily: "inherit" }}
         />


### PR DESCRIPTION
statsapi has full box scores back to 1901 (incl. Negro Leagues) and the tool already renders anything outside our 1950+ DB via the statsapi fallback — so the 1950 picker floor was arbitrary. Drops it to 1901; below that statsapi returns no games.

🤖 Generated with [Claude Code](https://claude.com/claude-code)